### PR TITLE
Fix: Resolve cookie parsing error and 401s by standardizing auth cook…

### DIFF
--- a/subclue-web/lib/auth/cookieHelpers.ts
+++ b/subclue-web/lib/auth/cookieHelpers.ts
@@ -18,9 +18,9 @@ export async function setAuthCookies(session: {
     path    : '/'
   }
 
-  store.set(`sb-${projectId}-auth-token`, session.access_token,  {
-    ...common, maxAge: session.expires_in
-  })
+  // store.set(`sb-${projectId}-auth-token`, session.access_token,  {
+  //   ...common, maxAge: session.expires_in
+  // })
 
   store.set(`sb-${projectId}-refresh-token`, session.refresh_token, {
     ...common, maxAge: ONE_YEAR


### PR DESCRIPTION
…ie management

The product creation API route (`/api/parceiro/produtos`) was returning a 401 Unauthorized error. This was traced to a `SyntaxError: Unexpected token 'b', "base64-eyJ"... is not valid JSON` when `createRouteHandlerClient` attempted to parse the Supabase auth cookie.

The root cause appeared to be a conflict between custom cookie setting logic in `lib/auth/cookieHelpers.ts` (specifically the `setAuthCookies` function) and the cookie format expected by the `@supabase/auth-helpers-nextjs` library. The `setAuthCookies` function was writing the raw access token to the `sb-<projectId>-auth-token` cookie. However, the auth helpers expect this cookie to contain a JSON-stringified session object.

This commit modifies `lib/auth/cookieHelpers.ts` by commenting out the line responsible for setting the `sb-<projectId>-auth-token` cookie. This change allows `createMiddlewareClient` (from `@supabase/auth-helpers-nextjs`, used in `middleware.ts`) to solely manage the creation and formatting of this crucial authentication cookie.

By ensuring the auth cookie is consistently formatted by the auth helpers library, `createRouteHandlerClient` should now be able to parse it correctly, resolving the session and preventing the 401 error.

You should clear browser cookies for the site and re-login to ensure the new cookie handling takes full effect.