### PR TITLE
Fix Supabase client factory

### DIFF
--- a/subclue-web/app/(auth)/signup/page.tsx
+++ b/subclue-web/app/(auth)/signup/page.tsx
@@ -6,7 +6,9 @@ import Image from 'next/image';
 import { FcGoogle } from "react-icons/fc";
 import { FaApple } from "react-icons/fa";
 import { cpf as cpfValidator } from 'cpf-cnpj-validator';
-import { supabase } from '@/lib/supabaseClient';
+import { createBrowserSupabase } from '@/lib/createBrowserSupabase';
+
+const supabase = createBrowserSupabase();
 
 export default function SignupPage() {
   const [userType, setUserType] = useState<'cliente' | 'empresa'>('cliente');

--- a/subclue-web/app/(mainApp)/painel/page.tsx
+++ b/subclue-web/app/(mainApp)/painel/page.tsx
@@ -2,7 +2,9 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { supabase } from "../../../lib/supabaseClient";
+import { createBrowserSupabase } from "../../../lib/createBrowserSupabase";
+
+const supabase = createBrowserSupabase();
 
 type Produto = { id: string; name: string; price: number };
 

--- a/subclue-web/lib/contexts/AuthContext.tsx
+++ b/subclue-web/lib/contexts/AuthContext.tsx
@@ -11,7 +11,7 @@ import React, {
   type ReactNode,
 } from 'react';
 import { useRouter } from 'next/navigation';
-import { createSupabaseBrowserClient } from '@/lib/supabase/client';
+import { createBrowserSupabase } from '@/lib/createBrowserSupabase';
 import type {
   User,
   Session,
@@ -42,7 +42,7 @@ interface AuthProviderProps {
 
 export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const router = useRouter();
-  const [supabase] = useState(() => createSupabaseBrowserClient());
+  const [supabase] = useState(() => createBrowserSupabase());
 
   const [user, setUser] = useState<User | null>(null);
   const [session, setSession] = useState<Session | null>(null);

--- a/subclue-web/lib/createBrowserSupabase.ts
+++ b/subclue-web/lib/createBrowserSupabase.ts
@@ -1,1 +1,9 @@
-import { createBrowserSupabase } from '@/lib/createBrowserSupabase'
+import { createBrowserClient } from '@supabase/ssr';
+import type { Database } from './database.types';
+
+export function createBrowserSupabase() {
+  return createBrowserClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
+}


### PR DESCRIPTION
## Summary
- implement `createBrowserSupabase` factory
- update AuthContext to use the new factory
- update sign‑up page to create a Supabase client via the factory
- update painel page to create a Supabase client via the factory

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d47e93dc832782d6d35a75429f76