### PR TITLE
Fix next image config

### DIFF
--- a/subclue-web/next.config.js
+++ b/subclue-web/next.config.js
@@ -3,21 +3,13 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    // 🍀 solução 1 — simples
-    domains: [
-      'res.cloudinary.com',          // Cloudinary
-      'lh3.googleusercontent.com'    // Google avatars
-    ],
-
-    /*  🍀 solução 2 — alternativa (remotePatterns)
-        Se preferir, comente o bloco "domains" e
-        use isso — mais flexível para caminhos específicos.
-
+    // Using remotePatterns avoids warnings about the deprecated "images.domains"
+    // property and allows more specific configuration.
     remotePatterns: [
       {
         protocol: 'https',
         hostname: 'res.cloudinary.com',
-        pathname: '/**',             // qualquer pasta/arquivo
+        pathname: '/**', // qualquer pasta/arquivo
       },
       {
         protocol: 'https',
@@ -25,7 +17,6 @@ const nextConfig = {
         pathname: '/**',
       },
     ],
-    */
   },
 };
 


### PR DESCRIPTION
## Summary
- remove deprecated `images.domains` and use `images.remotePatterns`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` in `subclue-web` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ed8ccbc08327886bc8e41f68ea7e