### PR TITLE
Fix AuthContext usages

### DIFF
--- a/subclue-web/app/(auth)/login/page.tsx
+++ b/subclue-web/app/(auth)/login/page.tsx
@@ -18,10 +18,12 @@ export default function LoginPage() {
   const {
     signInWithPassword,    // ← alterado aqui
     supabase,
-    isLoading,
-    serverSessionError,
-    setServerSessionError,
+    isLoadingSession,
+    authError,
+    clearAuthError,
   } = useAuth();
+
+  const isLoading = isLoadingSession;
 
   const [tipo,  setTipo]  = useState<'cliente' | 'empresa'>('cliente');
   const [email, setEmail] = useState('');
@@ -30,14 +32,14 @@ export default function LoginPage() {
 
   /* exibe erro vindo do contexto */
   useEffect(() => {
-    if (serverSessionError) setLocalErro(serverSessionError);
-  }, [serverSessionError]);
+    if (authError) setLocalErro(authError.message);
+  }, [authError]);
 
   /* ------------------ login e-mail/senha ------------------ */
   const handleLogin = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setLocalErro('');
-    if (serverSessionError) setServerSessionError(null);
+    if (authError) clearAuthError();
 
     if (!email || !senha) {
       setLocalErro('E-mail e senha são obrigatórios.');
@@ -51,7 +53,7 @@ export default function LoginPage() {
   /* ------------------ login social ------------------ */
   const handleSocialLogin = async (provider: 'google' | 'apple') => {
     setLocalErro('');
-    if (serverSessionError) setServerSessionError(null);
+    if (authError) clearAuthError();
 
     if (!supabase) {
       setLocalErro('Erro ao iniciar login social: cliente não disponível.');
@@ -68,7 +70,10 @@ export default function LoginPage() {
       },
     });
 
-    if (error) setServerSessionError(`Erro com ${provider}: ${error.message}`);
+    if (error) {
+      clearAuthError();
+      setLocalErro(`Erro com ${provider}: ${error.message}`);
+    }
   };
 
   /* ------------------ UI ------------------ */
@@ -110,9 +115,9 @@ export default function LoginPage() {
           </div>
 
           {/* erros */}
-          {(localErro || serverSessionError) && (
+          {(localErro || authError) && (
             <div className="bg-red-100 border border-red-400 text-red-700 px-3 py-2 rounded mb-4 text-center text-sm">
-              {localErro || serverSessionError}
+              {localErro || authError?.message}
             </div>
           )}
 

--- a/subclue-web/app/(auth)/signup/page.tsx
+++ b/subclue-web/app/(auth)/signup/page.tsx
@@ -6,13 +6,7 @@ import Image from 'next/image';
 import { FcGoogle } from "react-icons/fc";
 import { FaApple } from "react-icons/fa";
 import { cpf as cpfValidator } from 'cpf-cnpj-validator';
-<<<<<<< ours
-import { createBrowserSupabase } from '@/lib/createBrowserSupabase';
-
-const supabase = createBrowserSupabase();
-=======
 import { useAuth } from '@/lib/contexts/AuthContext';
->>>>>>> theirs
 
 export default function SignupPage() {
   const { supabase } = useAuth();

--- a/subclue-web/app/(mainApp)/painel/page.tsx
+++ b/subclue-web/app/(mainApp)/painel/page.tsx
@@ -2,13 +2,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-<<<<<<< ours
-import { createBrowserSupabase } from "../../../lib/createBrowserSupabase";
-
-const supabase = createBrowserSupabase();
-=======
 import { useAuth } from "@/lib/contexts/AuthContext";
->>>>>>> theirs
 
 type Produto = { id: string; name: string; price: number };
 

--- a/subclue-web/app/(mainApp)/painel/parceiros/page.tsx
+++ b/subclue-web/app/(mainApp)/painel/parceiros/page.tsx
@@ -7,7 +7,7 @@ import { useAuth } from '@/lib/contexts/AuthContext'; // Verifique o caminho
 
 // Remova a importação e uso do Header.tsx diretamente aqui
 export default function PainelParceiroDashboard() {
-  const { user, isLoading: authLoading } = useAuth(); // isLoading do AuthContext
+  const { user, isLoadingSession: authLoading } = useAuth(); // isLoading do AuthContext
 
   console.log('[PainelParceiroDashboard] user:', user?.id, 'isLoading:', authLoading);
 

--- a/subclue-web/components/ProtectedRoute.tsx
+++ b/subclue-web/components/ProtectedRoute.tsx
@@ -12,23 +12,23 @@ interface ProtectedRouteProps {
 }
 
 const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children, allowedRoles = [] }) => { // Default para array vazio
-  const { user, isLoading, userRole, isLoadingRole, serverSessionError } = useAuth();
+  const { user, isLoadingSession, userRole, isLoadingRole, authError } = useAuth();
   const router = useRouter();
 
   useEffect(() => {
     console.log('[ProtectedRoute] useEffect Check:', {
-      isLoading,
+      isLoading: isLoadingSession,
       isLoadingRole,
       user: !!user,
       userId: user?.id,
       userRole,
-      serverSessionError,
+      authError,
       passedAllowedRoles: allowedRoles, // Log para ver o que está sendo passado
       pathname: typeof window !== 'undefined' ? window.location.pathname : ''
     });
 
-    if (!isLoading && !isLoadingRole) {
-      if (!user || serverSessionError) {
+    if (!isLoadingSession && !isLoadingRole) {
+      if (!user || authError) {
         console.log('[ProtectedRoute] No user or serverSessionError. Redirecting to /login.');
         router.replace('/login');
       } else if (allowedRoles && allowedRoles.length > 0) { // Só checar papéis se allowedRoles for fornecido e não vazio
@@ -43,15 +43,15 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children, allowedRoles 
       // Se allowedRoles for um array vazio ou não fornecido, e o usuário estiver logado, permite o acesso.
       // (Pode ajustar essa lógica se rotas protegidas sempre exigirem pelo menos um papel).
     }
-  }, [user, isLoading, userRole, isLoadingRole, allowedRoles, router, serverSessionError]);
+  }, [user, isLoadingSession, userRole, isLoadingRole, allowedRoles, router, authError]);
 
-  if (isLoading || isLoadingRole) {
-    console.log('[ProtectedRoute] Showing LoadingScreen:', { isLoading, isLoadingRole });
+  if (isLoadingSession || isLoadingRole) {
+    console.log('[ProtectedRoute] Showing LoadingScreen:', { isLoading: isLoadingSession, isLoadingRole });
     return <LoadingScreen />;
   }
 
   // Condição final para renderizar ou não
-  if (!user || serverSessionError) {
+  if (!user || authError) {
     console.log('[ProtectedRoute] Final check: No user or serverSessionError. Not rendering children.');
     return <LoadingScreen />;
   }


### PR DESCRIPTION
## Summary
- remove leftover merge markers and use `useAuth` in painel pages
- rewrite login page and ProtectedRoute to use exported context fields
- update painel parceiro page to use `isLoadingSession`

## Testing
- `npx tsc -p subclue-web/tsconfig.json` *(fails: JSX intrinsic elements and module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840f2ab7bf48327b74bb8d07a5a8b32