### PR TITLE
Add auth cookie helpers

### DIFF
--- a/subclue-web/lib/auth/cookieHelpers.ts
+++ b/subclue-web/lib/auth/cookieHelpers.ts
@@ -1,0 +1,33 @@
+import { cookies } from 'next/headers'
+import type { Session } from '@supabase/supabase-js'
+
+/**
+ * Persists Supabase auth session tokens as HTTP only cookies so that
+ * subsequent server actions/components can authenticate requests.
+ */
+export async function setAuthCookies(session: Session) {
+  const store = await cookies()
+  const options = {
+    path: '/',
+    httpOnly: true,
+    sameSite: 'lax' as const,
+    secure: process.env.NODE_ENV === 'production'
+  }
+
+  store.set('sb-access-token', session.access_token, {
+    ...options,
+    maxAge: session.expires_in
+  })
+  store.set('sb-refresh-token', session.refresh_token, options)
+}
+
+/**
+ * Clears the auth cookies previously set with `setAuthCookies`.
+ */
+export async function clearAuthCookies() {
+  const store = await cookies()
+  const expireOptions = { path: '/', maxAge: 0 }
+
+  store.set('sb-access-token', '', expireOptions)
+  store.set('sb-refresh-token', '', expireOptions)
+}


### PR DESCRIPTION
## Summary
- implement server-side cookie helpers for authentication

## Testing
- `npx tsc -p subclue-web/test/tsconfig.json` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6840f6b59034832799aa8f53e9292dea