### PR TITLE
Add store parameter to Supabase server client

### DIFF
--- a/subclue-web/lib/supabase/server.ts
+++ b/subclue-web/lib/supabase/server.ts
@@ -3,9 +3,21 @@ import { cookies } from 'next/headers'
 import { createClient } from '@supabase/supabase-js'
 import type { Database } from '@/lib/database.types'
 
-export async function createSupabaseServerClient() {
-  const store   = await cookies() // ✅ obrigatório aguardar
-  const access  = store.get('sb-access-token')?.value
+/**
+ * Create a Supabase client for server environments. When `store` is omitted
+ * the cookie store from `next/headers` is used which requires an active Next.js
+ * request.  Providing a store allows the client to be created outside of a
+ * request context (e.g. during tests).
+ */
+export async function createSupabaseServerClient(
+  store?: ReturnType<typeof cookies>
+) {
+  // Only invoke `cookies()` when no store was supplied. Calling `cookies()`
+  // outside of a request context throws, so we avoid it when a custom store is
+  // passed (e.g. in tests).
+  const cookieStore = store ?? (await cookies())
+
+  const access = cookieStore?.get('sb-access-token')?.value
   const supabase = createClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
@@ -15,5 +27,5 @@ export async function createSupabaseServerClient() {
     }
   )
 
-  return { supabase, store }
+  return { supabase, store: cookieStore }
 }

--- a/subclue-web/test/serverClient.test.ts
+++ b/subclue-web/test/serverClient.test.ts
@@ -1,8 +1,17 @@
 import { createSupabaseServerClient } from '../lib/supabase/server';
 
+// Mock cookie store used during tests so that createSupabaseServerClient does
+// not rely on Next.js request context.
+const mockStore = {
+  get: (_name: string) => undefined,
+} as any;
+
 // Simple type check: ensure function returns Promise with supabase property
 async function check() {
-  const { supabase } = await createSupabaseServerClient();
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost';
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-key';
+
+  const { supabase } = await createSupabaseServerClient(mockStore);
   console.log(typeof supabase);
 }
 


### PR DESCRIPTION
## Summary
- make server Supabase client accept an optional cookie store
- update test to pass a mock store

## Testing
- `npm run check:supabase`
- `npm run test:supabase` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840fdbcbbf883278cb42cfd80e0f208