### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,6 @@
     "react-router-dom": "^6.30.0",
     "shadcn-ui": "^0.9.5"
   },
+  "license": "MIT",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/subclue-web/package.json
+++ b/subclue-web/package.json
@@ -2,6 +2,7 @@
   "name": "subclue-web",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary
- clarify project licensing by adding a `license` field in the root package.json
- include the same license in `subclue-web/package.json` to remove npm warnings

## Testing
- `yarn test:supabase` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/...)*

------
https://chatgpt.com/codex/tasks/task_e_684101f5388083278a7ab0200872da80