### PR TITLE
Add root dev script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Subclue
+
+Run the Next.js application located in `subclue-web` using the convenience script:
+
+```bash
+yarn dev
+```
+
+This command should be executed from the repository root and will run `next dev` inside the `subclue-web` folder.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "scripts": {
+    "dev": "yarn --cwd subclue-web dev",
     "test:supabase": "tsx subclue-web/test/serverClient.test.ts",
     "check:supabase": "sh scripts/check_supabase_export.sh"
   },


### PR DESCRIPTION
## Summary
- add `dev` script to run Next.js in subclue-web
- document how to run it from the repo root

## Testing
- `yarn test:supabase` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68410431df7883278862fa6777772665