### PR TITLE
Fix supabase client init in signout route

### DIFF
--- a/subclue-web/app/api/auth/signout/route.ts
+++ b/subclue-web/app/api/auth/signout/route.ts
@@ -9,8 +9,8 @@ export const dynamic = 'force-dynamic'; // Garante execução dinâmica
 
 export async function POST(request: Request) { // 'request' pode não ser usado, mas é padrão
   // O helper createSupabaseServerClient pode ser chamado diretamente aqui.
-  // Ele é uma função síncrona que retorna o cliente, mas as operações no cliente são async.
-  const supabase = createSupabaseServerClient(); // Não precisa de 'await' aqui para criar o cliente
+  // A função retorna uma Promise contendo o cliente configurado.
+  const { supabase } = await createSupabaseServerClient();
 
   console.log('[API_SIGNOUT_ROUTE_SSR] Rota POST chamada. Tentando supabase.auth.signOut()...');
   const { error } = await supabase.auth.signOut();


### PR DESCRIPTION
## Summary
- use async client creation when signing out

## Testing
- `npm run test:supabase` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68435b0273508327a916922a6fa6e49b