### PR TITLE
Add clearAuthCookies call in signout API

### DIFF
--- a/subclue-web/app/api/auth/signout/route.ts
+++ b/subclue-web/app/api/auth/signout/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from 'next/server';
 // Usando o mesmo helper das Server Actions e Server Components
 import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { clearAuthCookies } from '@/lib/auth/cookieHelpers';
 // createSupabaseServerClient já lida com 'cookies' de 'next/headers' internamente.
 // import type { Database } from '@/lib/database.types'; // O helper já é tipado com Database
 
@@ -14,6 +15,7 @@ export async function POST(request: Request) { // 'request' pode não ser usado,
 
   console.log('[API_SIGNOUT_ROUTE_SSR] Rota POST chamada. Tentando supabase.auth.signOut()...');
   const { error } = await supabase.auth.signOut();
+  await clearAuthCookies();
 
   if (error) {
     console.error('[API_SIGNOUT_ROUTE_SSR] Erro no Supabase signOut:', error);


### PR DESCRIPTION
## Summary
- clear session cookies in the signout API

## Testing
- `yarn test:supabase` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68435e2be9288327b97018d9c2bd2a91