### PR TITLE
Update Supabase test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "dev": "yarn --cwd subclue-web dev",
-    "test:supabase": "tsx subclue-web/test/serverClient.test.ts",
+    "test:supabase": "npx tsx subclue-web/test/serverClient.test.ts",
     "check:supabase": "sh scripts/check_supabase_export.sh"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- run the Supabase test using `npx tsx` so no global binary is required

## Testing
- `yarn test:supabase` *(fails: Error when performing the request to https://registry.yarnpkg.com/...)*

------
https://chatgpt.com/codex/tasks/task_e_68435f067b088327845a84d2a5b5d44b