### PR TITLE
Fix supabase session restore in server client

### DIFF
--- a/subclue-web/lib/supabase/server.ts
+++ b/subclue-web/lib/supabase/server.ts
@@ -18,6 +18,7 @@ export async function createSupabaseServerClient(
   const cookieStore = store ?? (await cookies())
 
   const access = cookieStore?.get('sb-access-token')?.value
+  const refresh = cookieStore?.get('sb-refresh-token')?.value
   const supabase = createClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
@@ -26,6 +27,10 @@ export async function createSupabaseServerClient(
       global: access ? { headers: { Authorization: `Bearer ${access}` } } : {}
     }
   )
+
+  if (access && refresh) {
+    await supabase.auth.setSession({ access_token: access, refresh_token: refresh })
+  }
 
   return { supabase, store: cookieStore }
 }

--- a/subclue-web/test/serverClient.test.ts
+++ b/subclue-web/test/serverClient.test.ts
@@ -1,18 +1,58 @@
-import { createSupabaseServerClient } from '../lib/supabase/server';
+import { createSupabaseServerClient } from '../lib/supabase/server'
+import { strict as assert } from 'node:assert'
 
-// Mock cookie store used during tests so that createSupabaseServerClient does
-// not rely on Next.js request context.
-const mockStore = {
-  get: (_name: string) => undefined,
-} as any;
+const expiredAccess = 'expired-access-token'
+const refreshToken = 'valid-refresh-token'
 
-// Simple type check: ensure function returns Promise with supabase property
-async function check() {
-  process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost';
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-key';
+let refreshCalled = false
 
-  const { supabase } = await createSupabaseServerClient(mockStore);
-  console.log(typeof supabase);
+global.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+  const url = typeof input === 'string' ? input : input.toString()
+  if (url.includes('/token')) {
+    refreshCalled = true
+    return new Response(
+      JSON.stringify({
+        access_token: 'new-access',
+        refresh_token: 'new-refresh',
+        token_type: 'bearer',
+        expires_in: 3600,
+        user: { id: '123', email: 'test@example.com' }
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
+  if (url.includes('/user')) {
+    return new Response(
+      JSON.stringify({ id: '123', email: 'test@example.com' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
+  return new Response('{}', { status: 200 })
 }
 
-check();
+const mockStore = {
+  get(name: string) {
+    if (name === 'sb-access-token') return { value: expiredAccess }
+    if (name === 'sb-refresh-token') return { value: refreshToken }
+    return undefined
+  }
+} as any
+
+async function run() {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost'
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-key'
+
+  const { supabase } = await createSupabaseServerClient(mockStore)
+  const { data: { user }, error } = await supabase.auth.getUser()
+
+  assert.equal(error, null)
+  assert.ok(user && user.id === '123')
+  assert.equal(refreshCalled, true)
+
+  console.log('all tests passed')
+}
+
+run().catch(err => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- read both sb-access-token and sb-refresh-token in server client
- automatically call `supabase.auth.setSession` when tokens are present
- extend tests to verify session restoration when access token is expired

## Testing
- `npm run check:supabase`
- `npm run test:supabase` *(fails: 403 Forbidden while fetching tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68437ace041883279ec1bca76cf50fec