### PR TITLE
Use getUser in product route

### DIFF
--- a/subclue-web/app/api/parceiro/produtos/route.ts
+++ b/subclue-web/app/api/parceiro/produtos/route.ts
@@ -41,11 +41,11 @@ const parseTags = (tagsString: string | null): string[] | null => {
 export async function POST(request: NextRequest) {
   const { supabase } = await createSupabaseServerClient();
 
-  const { data: { session }, error: sessionError } = await supabase.auth.getSession();
-  if (sessionError || !session?.user) {
+  const { data: { user }, error: userError } = await supabase.auth.getUser();
+  if (userError || !user) {
     return NextResponse.json({ error: 'Usuário não autenticado.' }, { status: 401 });
   }
-  const userId = session.user.id;
+  const userId = user.id;
 
   const { data: parceiroData, error: parceiroError } = await supabase
     .from('parceiros')


### PR DESCRIPTION
## Summary
- update parceiro produtos API to rely on `supabase.auth.getUser`

## Testing
- `npm run test:supabase` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68437f217a6c8327a69e51e1310777b0