### PR TITLE
Support hashed auth cookies in server client

### DIFF
--- a/subclue-web/test/serverClient.test.ts
+++ b/subclue-web/test/serverClient.test.ts
@@ -38,15 +38,44 @@ const mockStore = {
   }
 } as any
 
+function createHashedStore(ref: string) {
+  const payload = Buffer.from(
+    JSON.stringify({ access_token: expiredAccess, refresh_token: refreshToken })
+  ).toString('base64')
+  const mid = Math.ceil(payload.length / 2)
+  const p0 = payload.slice(0, mid)
+  const p1 = payload.slice(mid)
+  return {
+    get(name: string) {
+      if (name === `sb-${ref}-auth-token.0`) return { value: p0 }
+      if (name === `sb-${ref}-auth-token.1`) return { value: p1 }
+      return undefined
+    }
+  } as any
+}
+
 async function run() {
-  process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost'
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-key'
 
+  // legacy cookie format
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost'
+  refreshCalled = false
   const { supabase } = await createSupabaseServerClient(mockStore)
   const { data: { user }, error } = await supabase.auth.getUser()
 
   assert.equal(error, null)
   assert.ok(user && user.id === '123')
+  assert.equal(refreshCalled, true)
+
+  // hashed cookie format
+  const ref = 'projref'
+  process.env.NEXT_PUBLIC_SUPABASE_URL = `https://${ref}.supabase.co`
+  const { supabase: supabase2 } = await createSupabaseServerClient(createHashedStore(ref))
+  refreshCalled = false
+  const { data: { user: user2 }, error: error2 } = await supabase2.auth.getUser()
+
+  assert.equal(error2, null)
+  assert.ok(user2 && user2.id === '123')
   assert.equal(refreshCalled, true)
 
   console.log('all tests passed')


### PR DESCRIPTION
## Summary
- detect Supabase project ref from `NEXT_PUBLIC_SUPABASE_URL`
- read hashed auth cookies used by `@supabase/ssr`
- reconstruct session when any cookie format exists
- test `createSupabaseServerClient` against both cookie formats

## Testing
- `yarn test:supabase` *(fails: Error when performing the request to https://registry.yarnpkg.com/...)*

------
https://chatgpt.com/codex/tasks/task_e_6843820356348327bf56985a73bb64c7