### PR TITLE
Fix product creation auth check

### DIFF
--- a/subclue-web/app/(mainApp)/painel/parceiros/produtos/criar/page.tsx
+++ b/subclue-web/app/(mainApp)/painel/parceiros/produtos/criar/page.tsx
@@ -3,6 +3,7 @@
 
 import React, { useEffect, useState, FormEvent, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
+import { useAuth } from '@/lib/contexts/AuthContext';
 import SidebarParceiro from '@/components/SidebarParceiro';
 import { Loader2, Trash2, PlusCircle } from 'lucide-react';
 import { v4 as uuidv4 } from 'uuid'; // Para gerar IDs únicos
@@ -39,6 +40,7 @@ const formatarMoeda = (valor: string): string => {
 
 export default function CriarProdutoPage() {
   const router = useRouter();
+  const { accessToken } = useAuth();
   const [titulo, setTitulo] = useState('');
   const [slug, setSlug] = useState('');
   const [descricaoCurta, setDescricaoCurta] = useState('');
@@ -199,7 +201,17 @@ export default function CriarProdutoPage() {
       formData.append('tamanhos', JSON.stringify(tamanhos));
       formData.append('cores', JSON.stringify(cores));
 
-      const response = await fetch('/api/parceiro/produtos', { method: 'POST', body: formData });
+      const headers: HeadersInit = {};
+      if (accessToken) {
+        headers['Authorization'] = `Bearer ${accessToken}`;
+      }
+
+      const response = await fetch('/api/parceiro/produtos', {
+        method: 'POST',
+        body: formData,
+        headers,
+        credentials: 'include',
+      });
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
         throw new Error(errorData.error || `Erro ${response.status}`);

--- a/subclue-web/app/api/parceiro/produtos/route.ts
+++ b/subclue-web/app/api/parceiro/produtos/route.ts
@@ -41,7 +41,14 @@ const parseTags = (tagsString: string | null): string[] | null => {
 export async function POST(request: NextRequest) {
   const { supabase } = await createSupabaseServerClient();
 
-  const { data: { user }, error: userError } = await supabase.auth.getUser();
+  const authHeader = request.headers.get('authorization');
+  const bearerToken = authHeader?.startsWith('Bearer ')
+    ? authHeader.slice(7)
+    : undefined;
+
+  const { data: { user }, error: userError } = bearerToken
+    ? await supabase.auth.getUser(bearerToken)
+    : await supabase.auth.getUser();
   if (userError || !user) {
     return NextResponse.json({ error: 'Usuário não autenticado.' }, { status: 401 });
   }


### PR DESCRIPTION
## Summary
- send access token with product creation requests
- fallback to Authorization header in product creation API

## Testing
- `yarn lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438faa17288327bf2f43be67fa0989