### PR TITLE
Fix hydration warning

### DIFF
--- a/subclue-web/app/layout.tsx
+++ b/subclue-web/app/layout.tsx
@@ -21,7 +21,7 @@ export default function RootLayout({
     // Se GeistSans não estiver funcionando, substitua className={GeistSans.className} por sua fonte ou remova.
     // Exemplo com Inter: <html lang="pt-BR" className={inter.className}>
     <html lang="pt-BR" className={GeistSans.className}>
-      <body>
+      <body suppressHydrationWarning={true}>
         <Providers> {/* AuthProvider está dentro de Providers */}
           {children} {/* Isso renderizará AuthLayout ou MainAppLayout dependendo da rota */}
         </Providers>


### PR DESCRIPTION
## Summary
- suppress React hydration warning in the root layout

## Testing
- `yarn dev` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6843926a74ec8327af2fcc70be3ddb2b