### PR TITLE
Fix stale bearer usage in product creation

### DIFF
--- a/subclue-web/app/api/parceiro/produtos/route.ts
+++ b/subclue-web/app/api/parceiro/produtos/route.ts
@@ -41,14 +41,7 @@ const parseTags = (tagsString: string | null): string[] | null => {
 export async function POST(request: NextRequest) {
   const { supabase } = await createSupabaseServerClient();
 
-  const authHeader = request.headers.get('authorization');
-  const bearerToken = authHeader?.startsWith('Bearer ')
-    ? authHeader.slice(7)
-    : undefined;
-
-  const { data: { user }, error: userError } = bearerToken
-    ? await supabase.auth.getUser(bearerToken)
-    : await supabase.auth.getUser();
+  const { data: { user }, error: userError } = await supabase.auth.getUser();
   if (userError || !user) {
     return NextResponse.json({ error: 'Usuário não autenticado.' }, { status: 401 });
   }


### PR DESCRIPTION
## Summary
- drop Authorization header handling in product creation API
- rely on session cookies for authentication

## Testing
- `yarn test:supabase` *(fails: Cannot download supabase due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684359ee7ac88327a265b66d2991d6a4