### PR TITLE
Sync cookies on auth change

### DIFF
--- a/subclue-web/lib/contexts/AuthContext.tsx
+++ b/subclue-web/lib/contexts/AuthContext.tsx
@@ -84,6 +84,18 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       setUser(null);
       setSession(null);
       setAccessToken(null);
+      try {
+        await fetch('/auth/refresh', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          credentials: 'include',
+          body: JSON.stringify({ event: 'SIGNED_OUT', session: null }),
+        });
+      } catch (e) {
+        console.error('Failed to refresh auth on signOut', e);
+      }
       router.push('/login');
     }
   }, [supabase, router, clearAuthError]);
@@ -125,6 +137,19 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         setUser(session?.user ?? null);
         setSession(session);
         setAccessToken(session?.access_token ?? null);
+
+        try {
+          await fetch('/auth/refresh', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            credentials: 'include',
+            body: JSON.stringify({ event, session }),
+          });
+        } catch (e) {
+          console.error('Failed to refresh auth state', e);
+        }
 
         if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') {
           router.refresh(); // força update nas Server Components


### PR DESCRIPTION
## Summary
- trigger `/auth/refresh` whenever auth state changes to update cookies
- call `/auth/refresh` on sign out so cookies are cleared

## Testing
- `npm run test:supabase` *(fails: Cannot find module 'next/headers')*

------
https://chatgpt.com/codex/tasks/task_e_6843962d7ce883278371a124af8d5a00