### PR TITLE
Update signOut to invoke server logout

### DIFF
--- a/subclue-web/lib/contexts/AuthContext.tsx
+++ b/subclue-web/lib/contexts/AuthContext.tsx
@@ -85,16 +85,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       setSession(null);
       setAccessToken(null);
       try {
-        await fetch('/auth/refresh', {
+        await fetch('/api/auth/signout', {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
           credentials: 'include',
-          body: JSON.stringify({ event: 'SIGNED_OUT', session: null }),
         });
       } catch (e) {
-        console.error('Failed to refresh auth on signOut', e);
+        console.error('Failed to sign out on server', e);
       }
       router.push('/login');
     }


### PR DESCRIPTION
## Summary
- sign out via `/api/auth/signout` endpoint so cookies are cleared server side

## Testing
- `npm run check:supabase`
- `npx -y tsx subclue-web/test/serverClient.test.ts` *(fails: Cannot find module 'next/headers')*

------
https://chatgpt.com/codex/tasks/task_e_684397db50c08327ab34adcd83f55784