### PR TITLE
Fix authorization header handling

### DIFF
--- a/subclue-web/app/api/parceiro/produtos/route.ts
+++ b/subclue-web/app/api/parceiro/produtos/route.ts
@@ -41,7 +41,12 @@ const parseTags = (tagsString: string | null): string[] | null => {
 export async function POST(request: NextRequest) {
   const { supabase } = await createSupabaseServerClient();
 
-  const { data: { user }, error: userError } = await supabase.auth.getUser();
+  const authHeader = request.headers.get('authorization');
+  const token = authHeader?.toLowerCase().startsWith('bearer ')
+    ? authHeader.slice(7)
+    : authHeader ?? undefined;
+
+  const { data: { user }, error: userError } = await supabase.auth.getUser(token);
   if (userError || !user) {
     return NextResponse.json({ error: 'Usuário não autenticado.' }, { status: 401 });
   }


### PR DESCRIPTION
## Summary
- allow `/api/parceiro/produtos` to read the bearer token from the request

## Testing
- `npx -y tsx subclue-web/test/serverClient.test.ts` *(fails: Cannot find module 'next/headers')*

------
https://chatgpt.com/codex/tasks/task_e_6843a147ac788327a9112e57e456589b